### PR TITLE
build(deps): bump the rust-dependencies group across 1 directory with…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
+checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
 
 [[package]]
 name = "glib"
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libdisplay-info"
@@ -2298,7 +2298,7 @@ dependencies = [
  "smithay-drm-extras",
  "tracing",
  "tracing-subscriber",
- "tracy-client 0.18.0",
+ "tracy-client 0.18.1",
  "url",
  "wayland-backend",
  "wayland-client",
@@ -2322,7 +2322,7 @@ dependencies = [
  "regex",
  "smithay",
  "tracing",
- "tracy-client 0.18.0",
+ "tracy-client 0.18.1",
 ]
 
 [[package]]
@@ -3901,18 +3901,19 @@ checksum = "73202d787346a5418f8222eddb5a00f29ea47caf3c7d38a8f2f69f8455fa7c7e"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys",
+ "tracy-client-sys 0.24.3",
 ]
 
 [[package]]
 name = "tracy-client"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90a2c01305b02b76fdd89ac8608bae27e173c829a35f7d76a345ab5d33836db"
+checksum = "3927832d93178f979a970d26deed7b03510586e328f31b0f9ad7a73985b8332a"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys",
+ "tracy-client-sys 0.24.3",
+ "tracy-client-sys 0.25.0",
 ]
 
 [[package]]
@@ -3920,6 +3921,16 @@ name = "tracy-client-sys"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fff37da548239c3bf9e64a12193d261e8b22b660991c6fd2df057c168f435f"
+dependencies = [
+ "cc",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c032d68a49d25d9012a864fef1c64ac17aee43c87e0477bf7301d8ae8bfea7b7"
 dependencies = [
  "cc",
  "windows-targets 0.52.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tracing = { version = "0.1.41", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-tracy-client = { version = "0.18.0", default-features = false }
+tracy-client = { version = "0.18.1", default-features = false }
 
 [workspace.dependencies.smithay]
 # version = "0.4.1"
@@ -65,10 +65,10 @@ drm-ffi = "0.9.0"
 fastrand = "2.3.0"
 futures-util = { version = "0.3.31", default-features = false, features = ["std", "io"] }
 git-version = "0.3.9"
-glam = "0.30.3"
+glam = "0.30.4"
 input = { version = "0.9.1", features = ["libinput_1_21"] }
 keyframe = { version = "1.1.1", default-features = false }
-libc = "0.2.172"
+libc = "0.2.173"
 libdisplay-info = "0.2.2"
 log = { version = "0.4.27", features = ["max_level_trace", "release_max_level_debug"] }
 niri-config = { version = "25.5.1", path = "niri-config" }


### PR DESCRIPTION
… 3 updates

Bumps the rust-dependencies group with 3 updates in the / directory: [glam](https://github.com/bitshifter/glam-rs), [libc](https://github.com/rust-lang/libc) and [tracy-client](https://github.com/nagisa/rust_tracy_client).


Updates `glam` from 0.30.3 to 0.30.4
- [Changelog](https://github.com/bitshifter/glam-rs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/bitshifter/glam-rs/compare/0.30.3...0.30.4)

Updates `libc` from 0.2.172 to 0.2.173
- [Release notes](https://github.com/rust-lang/libc/releases)
- [Changelog](https://github.com/rust-lang/libc/blob/0.2.173/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/libc/compare/0.2.172...0.2.173)

Updates `tracy-client` from 0.18.0 to 0.18.1
- [Commits](https://github.com/nagisa/rust_tracy_client/compare/tracy-client-v0.18.0...tracy-client-v0.18.1)

---
updated-dependencies:
- dependency-name: glam dependency-version: 0.30.4 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-dependencies
- dependency-name: libc dependency-version: 0.2.173 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-dependencies
- dependency-name: tracy-client dependency-version: 0.18.1 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: rust-dependencies ...